### PR TITLE
GUNDI-4464: Add unit tests for device observation and authentication actions

### DIFF
--- a/app/actions/tests/test_client.py
+++ b/app/actions/tests/test_client.py
@@ -1,0 +1,61 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import app.actions.client as client
+
+@pytest.mark.asyncio
+async def test_get_devices_observations_success():
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=MagicMock(
+            json=MagicMock(return_value={
+                "success": True,
+                "message": "ok",
+                "data": {
+                    "devices": [
+                        {
+                            "id": 1,
+                            "name": "Device1",
+                            "DEVICE_COLLAR": "collar1",
+                            "LAT": 10.0,
+                            "LNG": 20.0,
+                            "DEVICE_TIME": "2024-01-01T00:00:00Z"
+                        },
+                        {
+                            "id": 2,
+                            "name": "Device2",
+                            "DEVICE_COLLAR": "collar2",
+                            "LAT": 11.0,
+                            "LNG": 21.0,
+                            "DEVICE_TIME": "2024-01-01T01:00:00Z"
+                        },
+                        {
+                            "id": 3,
+                            "name": "Device3",
+                            "DEVICE_COLLAR": "collar3",
+                            "LAT": 12.0,
+                            "LNG": 22.0,
+                            "DEVICE_TIME": "2024-01-01T02:00:00Z"
+                        }
+                    ],
+                    "history": []
+                }
+            }),
+            status_code=200
+    ))) as mock_get:
+        with patch("httpx.AsyncClient.__aenter__", new=AsyncMock(return_value=MagicMock(get=mock_get))):
+            result = await client.get_devices_observations("id", "url", {"username": "u", "password": "p"})
+            assert hasattr(result, "data")
+
+@pytest.mark.asyncio
+async def test_get_devices_observations_http_error():
+    # Simulate HTTP error
+    with patch("httpx.AsyncClient.get", new=AsyncMock(side_effect=Exception("HTTP error"))):
+        with pytest.raises(Exception):
+            await client.get_devices_observations("id", "url", {"username": "u", "password": "p"})
+
+@pytest.mark.asyncio
+async def test_get_devices_observations_invalid_response():
+    # Simulate invalid response (missing data)
+    with patch("httpx.AsyncClient.get", new=AsyncMock(return_value=MagicMock(json=MagicMock(return_value={}), status_code=200))):
+        with patch("httpx.AsyncClient.__aenter__", new=AsyncMock(return_value=MagicMock(get=AsyncMock()))):
+            with pytest.raises(Exception):
+                await client.get_devices_observations("id", "url", {"username": "u", "password": "p"})

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -62,10 +62,17 @@ async def test_action_pull_observations_success(mocker, mock_publish_event, inte
     assert result["observations_extracted"] == 1
 
 @pytest.mark.asyncio
-async def test_action_pull_observations_no_devices(integration_v2, auth_config):
+async def test_action_pull_observations_no_devices(mocker, mock_publish_event, integration_v2, auth_config):
     integration = integration_v2
     # Modify auth config
     integration.configurations[2].data = {"username": "user", "password": "pass"}
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.trigger_action", return_value=None)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.execute_action", return_value=None)
+
     devices_response = MagicMock(data=MagicMock(devices=None))
     with patch("app.actions.client.get_devices_observations", new=AsyncMock(return_value=devices_response)):
         result = await handlers.action_pull_observations(integration, MagicMock(gmt_offset=0))
@@ -111,10 +118,17 @@ async def test_action_pull_historical_observations_success(mocker, mock_publish_
     assert result["observations_extracted"] == 1
 
 @pytest.mark.asyncio
-async def test_action_pull_historical_observations_no_devices(integration_v2, auth_config):
+async def test_action_pull_historical_observations_no_devices(mocker, mock_publish_event, integration_v2, auth_config):
     integration = integration_v2
     # Modify auth config
     integration.configurations[2].data = {"username": "user", "password": "pass"}
+
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.trigger_action", return_value=None)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.execute_action", return_value=None)
+
     devices_response = MagicMock(data=MagicMock(history=None))
     with patch("app.actions.client.get_devices_observations", new=AsyncMock(return_value=devices_response)):
         result = await handlers.action_pull_historical_observations(

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -1,0 +1,134 @@
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import app.actions.handlers as handlers
+from app import settings
+
+@pytest_asyncio.fixture
+def auth_config():
+    class AuthConfig:
+        username = "user"
+        password = MagicMock()
+        password.get_secret_value.return_value = "pass"
+    return AuthConfig()
+
+@pytest.mark.asyncio
+async def test_action_auth_success(integration_v2, auth_config):
+    with patch("app.actions.client.get_devices_observations", new=AsyncMock()) as mock_get:
+        mock_get.return_value = MagicMock(data=MagicMock(devices=[1,2,3]))
+        result = await handlers.action_auth(integration_v2, auth_config)
+        assert result["valid_credentials"] is True
+
+@pytest.mark.asyncio
+async def test_action_auth_failure(integration_v2, auth_config):
+    with patch("app.actions.client.get_devices_observations", new=AsyncMock()) as mock_get:
+        mock_get.return_value = MagicMock(data=MagicMock(devices=None))
+        result = await handlers.action_auth(integration_v2, auth_config)
+        assert result["valid_credentials"] is False
+
+@pytest.mark.asyncio
+async def test_action_auth_http_error(integration_v2, auth_config):
+    with patch("app.actions.client.get_devices_observations", new=AsyncMock(side_effect=Exception("fail"))):
+        with pytest.raises(Exception):
+            await handlers.action_auth(integration_v2, auth_config)
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_success(mocker, mock_publish_event, integration_v2, auth_config):
+    integration = integration_v2
+    # Modify auth config
+    integration.configurations[2].data = {"username": "user", "password": "pass"}
+
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", return_value=None)
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", return_value=None)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.trigger_action", return_value=None)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.execute_action", return_value=None)
+
+    device = MagicMock()
+    device.DEVICE_COLLAR = "collar"
+    device.DEVICE_TIME = handlers.datetime.now()
+    device.LAT = 1.0
+    device.LNG = 2.0
+    device.dict.return_value = {}
+    devices_response = MagicMock(data=MagicMock(devices=[device]))
+
+    mocker.patch("app.actions.client.get_devices_observations", new=AsyncMock(return_value=devices_response))
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", new=AsyncMock(return_value=[1]))
+
+    result = await handlers.action_pull_observations(integration, MagicMock(gmt_offset=0))
+    assert result["observations_extracted"] == 1
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_no_devices(integration_v2, auth_config):
+    integration = integration_v2
+    # Modify auth config
+    integration.configurations[2].data = {"username": "user", "password": "pass"}
+    devices_response = MagicMock(data=MagicMock(devices=None))
+    with patch("app.actions.client.get_devices_observations", new=AsyncMock(return_value=devices_response)):
+        result = await handlers.action_pull_observations(integration, MagicMock(gmt_offset=0))
+        assert result["devices_triggered"] == 0
+
+@pytest.mark.asyncio
+async def test_action_pull_observations_exception(integration_v2, auth_config):
+    integration = integration_v2
+    # Modify auth config
+    integration.configurations[2].data = {"username": "user", "password": "pass"}
+    with patch("app.actions.client.get_devices_observations", new=AsyncMock(side_effect=Exception("fail"))):
+        with pytest.raises(Exception):
+            await handlers.action_pull_observations(integration, MagicMock(gmt_offset=0))
+
+@pytest.mark.asyncio
+async def test_action_pull_historical_observations_success(mocker, mock_publish_event, integration_v2, auth_config):
+    integration = integration_v2
+    # Modify auth config
+    integration.configurations[2].data = {"username": "user", "password": "pass"}
+
+    mocker.patch("app.services.state.IntegrationStateManager.get_state", return_value=None)
+    mocker.patch("app.services.state.IntegrationStateManager.set_state", return_value=None)
+    mocker.patch("app.services.activity_logger.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_scheduler.trigger_action", return_value=None)
+    mocker.patch("app.services.action_scheduler.publish_event", mock_publish_event)
+    mocker.patch("app.services.action_runner.execute_action", return_value=None)
+
+    device = MagicMock()
+    device.DEVICE_COLLAR = "collar"
+    device.DEVICE_TIME = handlers.datetime.now()
+    device.LAT = 1.0
+    device.LNG = 2.0
+    device.dict.return_value = {}
+    devices_response = MagicMock(data=MagicMock(history=[device]))
+
+    mocker.patch("app.actions.client.get_devices_observations", new=AsyncMock(return_value=devices_response))
+    mocker.patch("app.actions.handlers.send_observations_to_gundi", new=AsyncMock(return_value=[1]))
+
+    result = await handlers.action_pull_historical_observations(
+        integration, MagicMock(start_date="2020-01-01", end_date="2020-01-02", gmt_offset=0)
+    )
+    assert result["observations_extracted"] == 1
+
+@pytest.mark.asyncio
+async def test_action_pull_historical_observations_no_devices(integration_v2, auth_config):
+    integration = integration_v2
+    # Modify auth config
+    integration.configurations[2].data = {"username": "user", "password": "pass"}
+    devices_response = MagicMock(data=MagicMock(history=None))
+    with patch("app.actions.client.get_devices_observations", new=AsyncMock(return_value=devices_response)):
+        result = await handlers.action_pull_historical_observations(
+            integration, MagicMock(start_date="2020-01-01", end_date="2020-01-02", gmt_offset=0)
+        )
+        assert result["devices_triggered"] == 0
+
+@pytest.mark.asyncio
+async def test_action_pull_historical_observations_exception(integration_v2, auth_config):
+    integration = integration_v2
+    # Modify auth config
+    integration.configurations[2].data = {"username": "user", "password": "pass"}
+    with patch("app.actions.client.get_devices_observations", new=AsyncMock(side_effect=Exception("fail"))):
+        with pytest.raises(Exception):
+            await handlers.action_pull_historical_observations(
+                integration, MagicMock(start_date="2020-01-01", end_date="2020-01-02", gmt_offset=0)
+            )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = app/actions/test


### PR DESCRIPTION
This pull request introduces comprehensive test coverage for the `client` and `handlers` modules, along with configuration updates for the pytest framework. 

The changes focus on ensuring robust validation of asynchronous functions and error handling, as well as enabling targeted testing within the `app/actions/test` directory.

### Tests for `client` module:
* Added tests for `get_devices_observations` to validate successful responses, HTTP errors, and invalid responses. These tests use `pytest.mark.asyncio` and mock external calls with `AsyncMock` to simulate various scenarios.

### Tests for `handlers` module:
* Implemented tests for `action_auth` to verify authentication success and failure cases, as well as handling HTTP errors.
* Added tests for `action_pull_observations` to check device extraction functionality, including cases with no devices and exceptions.
* Added tests for `action_pull_historical_observations` to validate historical data extraction, including scenarios with no devices and exception handling.

### Pytest configuration:
* Updated `pytest.ini` to specify `app/actions/test` as the test path, ensuring pytest runs tests only within the designated directory.